### PR TITLE
Make data not found reason accessible to delegate

### DIFF
--- a/StreamingKit.podspec
+++ b/StreamingKit.podspec
@@ -1,8 +1,8 @@
 Pod::Spec.new do |s|
   s.name         = "StreamingKit"
-  s.version      = "0.1.29"
+  s.version      = "0.1.30"
   s.summary      = "A fast and extensible audio streamer for iOS and OSX with support for gapless playback and custom (non-HTTP) sources."
-  s.homepage     = "https://github.com/tumtumtum/StreamingKit/"
+  s.homepage     = "https://github.com/eirikurorri/StreamingKit/"
   s.license      = 'MIT'
   s.author       = { "Thong Nguyen" => "tumtumtum@gmail.com" }
   s.source       = { :git => "https://github.com/tumtumtum/StreamingKit.git", :tag => s.version.to_s}

--- a/StreamingKit/StreamingKit/STKAudioPlayer.h
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.h
@@ -79,6 +79,13 @@ typedef NS_ENUM(NSInteger, STKAudioPlayerErrorCode)
     STKAudioPlayerErrorOther = 0xffff
 };
 
+typedef NS_ENUM(NSInteger, STKErrorDataNotFoundReason)
+{
+    STKErrorDataNotFoundReasonNone = 0,
+    STKErrorDataNotFoundReasonForbidden,
+    STKErrorDataNotFoundReasonOther = 0xffff
+};
+
 ///
 /// Options to initiailise the Audioplayer with.
 /// By default if you set buffer size or seconds to 0, the non-zero default will be used
@@ -166,6 +173,8 @@ typedef void(^STKFrameFilter)(UInt32 channelsPerFrame, UInt32 bytesPerFrame, UIn
 @property (readonly) STKAudioPlayerOptions options;
 /// Gets the reason why the player is stopped (if any)
 @property (readonly) STKAudioPlayerStopReason stopReason;
+/// Gets the reason why data was not found (if any)
+@property (readonly) STKErrorDataNotFoundReason dataNotFoundReason;
 /// Gets and sets the delegate used for receiving events from the STKAudioPlayer
 @property (readwrite, unsafe_unretained) id<STKAudioPlayerDelegate> delegate;
 

--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -487,6 +487,10 @@ static void AudioFileStreamPacketsProc(void* clientData, UInt32 numberBytes, UIn
     return stopReason;
 }
 
+-(STKErrorDataNotFoundReason) dataNotFoundReason {
+    return dataNotFoundReason;
+}
+
 -(void) logInfo:(NSString*)line
 {
     if ([NSThread currentThread].isMainThread)

--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -560,6 +560,8 @@ static void AudioFileStreamPacketsProc(void* clientData, UInt32 numberBytes, UIn
         
         upcomingQueue = [[NSMutableArray alloc] init];
         bufferingQueue = [[NSMutableArray alloc] init];
+        
+        dataNotFoundReason = STKErrorDataNotFoundReasonNone;
 
 		[self resetPcmBuffers];
         [self createAudioGraph];

--- a/StreamingKit/StreamingKit/STKAudioPlayer.m
+++ b/StreamingKit/StreamingKit/STKAudioPlayer.m
@@ -409,6 +409,7 @@ static void AudioFileStreamPacketsProc(void* clientData, UInt32 numberBytes, UIn
         case STKAudioPlayerInternalStateInitialised:
             newState = STKAudioPlayerStateReady;
 			stopReason = STKAudioPlayerStopReasonNone;
+            dataNotFoundReason = STKErrorDataNotFoundReasonNone;
             break;
         case STKAudioPlayerInternalStateRunning:
         case STKAudioPlayerInternalStateStartingThread:
@@ -561,8 +562,6 @@ static void AudioFileStreamPacketsProc(void* clientData, UInt32 numberBytes, UIn
         upcomingQueue = [[NSMutableArray alloc] init];
         bufferingQueue = [[NSMutableArray alloc] init];
         
-        dataNotFoundReason = STKErrorDataNotFoundReasonNone;
-
 		[self resetPcmBuffers];
         [self createAudioGraph];
         [self createPlaybackThread];


### PR DESCRIPTION
This is done so that the delegate can access a more granular reason why a streaming url request has failed. Specifically, we want to relay a 403 error to the delegate.

The first impulse was to add a new enum case to STKAudioPlayerErrorCode, such as STKAudioPlayerErrorCodeForbidden, but that would risk breaking pattern matching for other users of the library.

So this solution uses a new property called dataNotFoundReason that the delegate can query upon receiving a audioPlayer: unexpectedError: call.

More header responses can be parsed in the future if needed.